### PR TITLE
Use Supabase for flame counts and add genre legend

### DIFF
--- a/pulse/index.html
+++ b/pulse/index.html
@@ -5,27 +5,44 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>BAC Pulse</title>
     <link rel="stylesheet" href="style.css" />
+    <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.45.1/dist/umd/supabase.min.js"></script>
   </head>
   <body>
-    <header>
-      <h1>BAC Pulse</h1>
-      <div id="week-selector" class="week-selector">
-        <button id="prev-week" aria-label="previous week">&#10094;</button>
-        <span id="week-range"></span>
-        <button id="next-week" aria-label="next week">&#10095;</button>
-      <button id="today-btn" aria-label="today" title="Zur heutigen Woche springen">Heute</button>
-      </div>
-    </header>
+      <header>
+        <h1>
+          BAC
+          <img src="pulseflame.png" alt="BAC flame logo" />
+        </h1>
+        <div class="header-right">
+          <div id="total-flames" class="total-flames">0🔥</div>
+          <div id="week-selector" class="week-selector">
+            <button id="prev-week" aria-label="previous week">&#10094;</button>
+            <span id="week-range"></span>
+            <button id="next-week" aria-label="next week">&#10095;</button>
+            <button id="today-btn" aria-label="today" title="Zur heutigen Woche springen">Heute</button>
+          </div>
+        </div>
+      </header>
     <main>
       <section id="hot-three" class="hot-section">
         <h2>Hot&nbsp;Three</h2>
         <div id="hot-three-list" class="event-container"></div>
       </section>
-      <section id="events" class="events-section">
-        <div id="day-selector" class="day-selector"></div>
-        <div id="event-list" class="event-container"></div>
-        <div id="location-list" class="location-list"></div>
-      </section>
+        <section id="events" class="events-section">
+          <div id="day-selector" class="day-selector"></div>
+          <div id="event-list" class="event-container"></div>
+          <div id="genre-legend" class="genre-legend">
+            <p>Farben = Musik-Genres</p>
+            <ul>
+              <li><span class="swatch" style="background-color:#39ff14;"></span> House = Neon-Grün</li>
+              <li><span class="swatch" style="background-color:#00bfff;"></span> Techno = Neon-Blau</li>
+              <li><span class="swatch" style="background-color:#ff00ff;"></span> Pop = Neon-Lila</li>
+              <li><span class="swatch" style="background-color:#ff3131;"></span> Hip-Hop = Neon-Rot</li>
+              <li><span class="swatch" style="background-color:#ff8c00;"></span> RnB = Neon-Orange</li>
+            </ul>
+          </div>
+          <div id="location-list" class="location-list"></div>
+        </section>
     </main>
     <script src="script.js"></script>
   </body>

--- a/pulse/style.css
+++ b/pulse/style.css
@@ -36,6 +36,25 @@ header h1 {
   font-weight: bold;
   letter-spacing: 1px;
   color: #39ff14; /* neon green title */
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+header h1 img {
+  height: 1.8rem;
+}
+
+.header-right {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
+
+.total-flames {
+  font-size: 1.2rem;
+  color: #ff6f61;
+  font-weight: bold;
 }
 
 /* Week selector */
@@ -230,6 +249,34 @@ section.events-section h2 {
   font-size: 0.8rem;
   color: #ccccff;
   white-space: nowrap;
+}
+
+/* Genre legend */
+.genre-legend {
+  margin-top: 1rem;
+  color: #ccccff;
+  font-size: 0.9rem;
+}
+
+.genre-legend ul {
+  list-style: none;
+  margin-top: 0.5rem;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem 1rem;
+}
+
+.genre-legend li {
+  display: flex;
+  align-items: center;
+  gap: 0.3rem;
+}
+
+.genre-legend .swatch {
+  width: 12px;
+  height: 12px;
+  border-radius: 2px;
+  display: inline-block;
 }
 
 /* Hot three cards emphasise ranking */


### PR DESCRIPTION
## Summary
- Store event flame votes in Supabase and show total flames
- Replace header text with BAC logo and add global counter
- Add color legend for genres

## Testing
- `npm test` *(fails: Could not read package.json)*


------
https://chatgpt.com/codex/tasks/task_e_6894c2f10d6c832c9acdc62c0162c8b1