### PR TITLE
Use Berlin timezone for today button

### DIFF
--- a/pulse/script.js
+++ b/pulse/script.js
@@ -237,6 +237,21 @@ const year = date.getFullYear();
   }
 
   /**
+   * Get today's date in the Europe/Berlin timezone.
+   * @returns {Date}
+   */
+  function getBerlinToday() {
+    const formatter = new Intl.DateTimeFormat('en-CA', {
+      timeZone: 'Europe/Berlin',
+      year: 'numeric',
+      month: '2-digit',
+      day: '2-digit',
+    });
+    const iso = formatter.format(new Date());
+    return new Date(iso);
+  }
+
+  /**
    * Read vote count for a given event ID from localStorage.
    * @param {string} eventId
    */
@@ -651,7 +666,7 @@ const year = date.getFullYear();
     // Today button: jump to current date and week
     if (todayBtn) {
       todayBtn.addEventListener('click', () => {
-        const now = new Date();
+        const now = getBerlinToday();
         const todayIso = toISODate(now);
         selectedDate = new Date(todayIso);
         currentWeekStart = getWeekStart(selectedDate);


### PR DESCRIPTION
## Summary
- add `getBerlinToday` helper to normalize dates to Europe/Berlin
- have the Today button jump to Berlin's current day and rerender affected lists

## Testing
- `node --check pulse/script.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6894cf2574c0832c9131fd14413d5d63